### PR TITLE
Retarget html2rss configs documentation links

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -11,7 +11,9 @@ export default defineConfig({
     "/configs": "/feed-directory/",
     "/components/html2rss-web": "/web-application/",
     "/components/html2rss": "/ruby-gem/",
-    "/components/html2rss-configs": "/html2rss-configs/",
+    "/components/html2rss-configs": "/creating-custom-feeds/",
+    "/html2rss-configs": "/creating-custom-feeds/",
+    "/html2rss-configs/": "/creating-custom-feeds/",
     "/components": "/",
   },
   build: {
@@ -305,7 +307,7 @@ export default defineConfig({
         },
         {
           label: "Write Your Own Feed Configs",
-          link: "/html2rss-configs",
+          link: "/creating-custom-feeds",
         },
         {
           label: "About",

--- a/src/content/docs/common-use-cases.mdx
+++ b/src/content/docs/common-use-cases.mdx
@@ -102,7 +102,7 @@ Follow multiple open source projects and their updates.
 1. **Identify the websites** you want to follow
 2. **Check our [Feed Directory](/feed-directory/)** to see if feeds already exist
 3. **Try the [Web App](/web-application/getting-started)** to create feeds easily
-4. **Learn advanced techniques** with our [Config Guide](/html2rss-configs/)
+4. **Learn advanced techniques** with our [Config Guide](/creating-custom-feeds)
 
 ---
 


### PR DESCRIPTION
## Summary
- retarget the sidebar entry and related redirect to the Creating Custom Feeds doc
- add redirects so legacy /html2rss-configs URLs land on the new canonical page
- update the Common Use Cases guide to reference the Creating Custom Feeds documentation

## Testing
- not run (docs change)


------
https://chatgpt.com/codex/tasks/task_e_68e67b2983c0832d94df35df353535d5