### PR TITLE
Rephrase tutorial contribution invite

### DIFF
--- a/src/content/docs/web-application/tutorials/index.mdx
+++ b/src/content/docs/web-application/tutorials/index.mdx
@@ -1,0 +1,33 @@
+---
+title: "Tutorials"
+description: "Step-by-step walkthroughs that help you build confidence with html2rss-web."
+sidebar:
+  label: "Tutorials overview"
+  order: 1
+---
+
+Welcome to the tutorial hub for the html2rss web application. Each guide is written for curious feed builders who prefer a walkthrough over reference docs.
+
+## Who these tutorials are for
+
+If you are experimenting with html2rss-web for the first time, the tutorials will help you:
+
+- Understand how the interface pieces fit together.
+- Practice building feeds from real-world sites.
+- Learn how to iterate safely without impacting production feeds.
+
+Already comfortable with the basics? Use the tutorials as a refresher before trying more advanced automation in the [How-to guides](/web-application/how-to/) and [Reference docs](/web-application/reference/).
+
+## What to expect next
+
+We are actively drafting scenario-based lessons that cover topics such as:
+
+1. Publishing your first feed from a news site.
+2. Monitoring marketplace listings with filters.
+3. Sharing a feed with teammates using private instances.
+
+Check back soon—new tutorials will appear in this section automatically as they are published.
+
+## Share your own walkthroughs
+
+html2rss thrives on the ingenuity of its community. If you have a creative workflow or story that others could learn from, [open a pull request](https://github.com/html2rss/html2rss.github.io/pulls) or start a discussion with your notes. We welcome community-authored tutorials that showcase custom use cases, mission-driven tactics, and lessons learned in the field.


### PR DESCRIPTION
## Summary
- soften the tutorial contribution invitation to spotlight community creativity without using the banned term

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e67b217414832d93da7b8ad5cc6dc7