### PR TITLE
docs: centralize docker compose quick start

### DIFF
--- a/src/content/docs/web-application/getting-started.mdx
+++ b/src/content/docs/web-application/getting-started.mdx
@@ -34,9 +34,9 @@ Ready to run your own html2rss-web instance? This guide walks you through every 
 
 ---
 
-## Installation Guide
+## Docker Compose Quick Start {#docker-compose-quick-start}
 
-This guide will help you set up your own copy of html2rss-web on your computer. Don't worry - we'll walk you through every step!
+This is the canonical Docker Compose walkthrough for html2rss-web. Follow the steps below to set up your own copy on a local machine or server — we'll walk you through every detail!
 
 ### What You'll Need
 

--- a/src/content/docs/web-application/how-to/deployment.mdx
+++ b/src/content/docs/web-application/how-to/deployment.mdx
@@ -3,33 +3,16 @@ title: "Deployment & Production"
 description: "Deploy html2rss-web to production with Docker. Learn best practices for hosting public instances with security, monitoring, and reliability."
 ---
 
-import { Steps } from '@astrojs/starlight/components';
-
-html2rss-web is published on Docker Hub, making it easy to deploy with Docker. The [`docker-compose.yml`](https://github.com/html2rss/html2rss-web/blob/master/docker-compose.yml) from our [Installation Guide](/web-application/getting-started) provides a solid foundation for both development and production use.
+html2rss-web is published on Docker Hub, making it easy to deploy with Docker. The [`docker-compose.yml`](https://github.com/html2rss/html2rss-web/blob/master/docker-compose.yml) from our [Docker Compose Quick Start](/web-application/getting-started/#docker-compose-quick-start) provides a solid foundation for both development and production use.
 
 ## Quick Start
 
-<Steps>
+For the full, step-by-step walkthrough, follow the [Docker Compose Quick Start](/web-application/getting-started/#docker-compose-quick-start). In brief, you'll:
 
-1. **Create a directory** for your instance:
-   ```bash
-   mkdir html2rss-web && cd html2rss-web
-   ```
-
-2. **Download the configuration** files:
-   ```bash
-   curl -O https://raw.githubusercontent.com/html2rss/html2rss-web/master/docker-compose.yml
-   curl -O https://raw.githubusercontent.com/html2rss/html2rss-web/master/config/feeds.yml
-   ```
-
-3. **Start the instance**:
-   ```bash
-   docker compose up -d
-   ```
-
-4. **Verify it's running** by opening [http://localhost:3000](http://localhost:3000) in your browser.
-
-</Steps>
+- Create a project directory for html2rss-web
+- Download or create the provided `docker-compose.yml` and `feeds.yml`
+- Start the stack with `docker compose up -d`
+- Confirm the UI loads at [http://localhost:3000](http://localhost:3000)
 
 > 📖 Need Docker? Follow the [Docker installation guide](https://docs.docker.com/get-docker/) and [Docker Compose install](https://docs.docker.com/compose/install/).
 


### PR DESCRIPTION
## Summary
- mark the getting started guide as the canonical Docker Compose quick start and add an explicit anchor
- replace the duplicated deployment steps with a brief summary that links back to the canonical guide

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e67fc18fe0832daf33033abc49ef0e