### PR TITLE
Fix automatic updates guide installation link

### DIFF
--- a/src/content/docs/web-application/how-to/automatic-updates.mdx
+++ b/src/content/docs/web-application/how-to/automatic-updates.mdx
@@ -7,4 +7,4 @@ sidebar:
 
 The [watchtower](https://containrrr.dev/watchtower/) service automatically pulls running Docker images and checks for updates. If an update is available, it will automatically start the updated image with the same configuration as the running one. Please read its manual.
 
-The `docker-compose.yml` in the [Installation Guide](/web-application/installation) contains a service description for watchtower.
+The `docker-compose.yml` in the [Installation Guide](/web-application/getting-started#installation-guide) contains a service description for watchtower.


### PR DESCRIPTION
## Summary
- correct the automatic updates guide to link to the current installation instructions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690240f2194c832db2bcec2046bbeb0f