### PR TITLE
Fix advanced techniques link target

### DIFF
--- a/src/content/docs/common-use-cases.mdx
+++ b/src/content/docs/common-use-cases.mdx
@@ -102,7 +102,7 @@ Follow multiple open source projects and their updates.
 1. **Identify the websites** you want to follow
 2. **Check our [Feed Directory](/feed-directory/)** to see if feeds already exist
 3. **Try the [Web App](/web-application/getting-started)** to create feeds easily
-4. **Learn advanced techniques** with our [Config Guide](/html2rss-configs/)
+4. **Learn advanced techniques** with our [Config Guide](/creating-custom-feeds/)
 
 ---
 


### PR DESCRIPTION
## Summary
- point the advanced techniques bullet on the common use cases page to the creating custom feeds guide

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690240d3f0ec832d892eec0509438752