### PR TITLE
docs(ruby-gem): document pagination strategies and request ceilings

### DIFF
--- a/src/content/docs/ruby-gem/index.mdx
+++ b/src/content/docs/ruby-gem/index.mdx
@@ -10,8 +10,11 @@ This section provides comprehensive documentation for the `html2rss` Ruby gem.
 If you are looking for the stable machine-readable contract for config authoring, use the JSON Schema exported by the core repo:
 
 - Repository file: [**`html2rss-config.schema.json`**](https://github.com/html2rss/html2rss/blob/master/schema/html2rss-config.schema.json)
-- CLI export: `html2rss schema`
-- Runtime validation: `html2rss validate config.yml`
+- CLI export: `html2rss schema` (also `--write`, `--no-pretty`)
+- Runtime validation: `html2rss validate config.yml` or `Html2rss::Config.validate`
+- Ruby discovery: `Html2rss::Config.json_schema` / `Html2rss::Config.schema_path`
+
+The exported schema covers client-side validation. Runtime validation remains authoritative for dynamic cross-field checks such as selector-key references. Contributors regenerating the checked-in artifact should run `bundle exec rake config:schema` in the core repo.
 
 ## Getting Started
 

--- a/src/content/docs/ruby-gem/reference/auto-source.mdx
+++ b/src/content/docs/ruby-gem/reference/auto-source.mdx
@@ -24,11 +24,12 @@ To enable it, add `auto_source: {}` to your configuration:
 
 1.  **`wordpress_api`:** Detects the `<link rel="https://api.w.org/">` tag used by WordPress and pulls posts from the REST API without parsing article HTML. See [WordPress API](/ruby-gem/reference/wordpress-api/).
 2.  **`sitemap`:** Automatically locates XML sitemap documents (`<link rel="sitemap">`, `/sitemap.xml`, or `/robots.txt`), filtering entries by priority and recency, with support for Google News tags (`<news:news>`).
-3.  **`schema`:** Parses `<script type="json/ld">` tags containing structured data (e.g., [Schema.org](https://schema.org/)).
-4.  **`microdata`:** Extracts HTML Microdata annotations (`itemscope itemtype`).
-5.  **`semantic_html`:** Searches for semantic HTML5 tags like `<article>`, `<main>`, and `<section>`.
-6.  **`html`:** Analyzes the HTML structure to find frequently occurring selectors that are likely to contain the main content.
-7.  **`json_state`:** Single-page applications often stash pre-rendered article data in `<script type="application/json">` tags or global variables
+3.  **`meta_oembed`:** Extracts single-item articles, video pages, and media updates from OpenGraph/Twitter meta tags and resolves JSON oEmbed endpoints (`<link rel="alternate" type="application/json+oembed">`).
+4.  **`schema`:** Parses `<script type="json/ld">` tags containing structured data (e.g., [Schema.org](https://schema.org/)).
+5.  **`microdata`:** Extracts HTML Microdata annotations (`itemscope itemtype`).
+6.  **`semantic_html`:** Searches for semantic HTML5 tags like `<article>`, `<main>`, and `<section>`.
+7.  **`html`:** Analyzes the HTML structure to find frequently occurring selectors that are likely to contain the main content.
+8.  **`json_state`:** Single-page applications often stash pre-rendered article data in `<script type="application/json">` tags or global variables
     such as `window.__NEXT_DATA__`, `window.__NUXT__`, or `window.STATE`. The JSON-state scraper walks those blobs, finds arrays with
     `title`/`url` pairs, and converts them into the same hashes produced by `HtmlExtractor`.
 
@@ -57,6 +58,8 @@ Enable or disable specific scrapers and adjust their settings:
         enabled: true # default: true
         min_priority: 0.3 # default: 0.3
         max_age_days: 30 # default: 30
+      meta_oembed:
+        enabled: true # default: true
       schema:
         enabled: false # default: true
       semantic_html:

--- a/src/content/docs/ruby-gem/reference/auto-source.mdx
+++ b/src/content/docs/ruby-gem/reference/auto-source.mdx
@@ -23,10 +23,12 @@ To enable it, add `auto_source: {}` to your configuration:
 `auto_source` uses the following strategies to find content:
 
 1.  **`wordpress_api`:** Detects the `<link rel="https://api.w.org/">` tag used by WordPress and pulls posts from the REST API without parsing article HTML. See [WordPress API](/ruby-gem/reference/wordpress-api/).
-2.  **`schema`:** Parses `<script type="json/ld">` tags containing structured data (e.g., [Schema.org](https://schema.org/)).
-3.  **`semantic_html`:** Searches for semantic HTML5 tags like `<article>`, `<main>`, and `<section>`.
-4.  **`html`:** Analyzes the HTML structure to find frequently occurring selectors that are likely to contain the main content.
-5.  **json_state:** Single-page applications often stash pre-rendered article data in `<script type="application/json">` tags or global variables
+2.  **`sitemap`:** Automatically locates XML sitemap documents (`<link rel="sitemap">`, `/sitemap.xml`, or `/robots.txt`), filtering entries by priority and recency, with support for Google News tags (`<news:news>`).
+3.  **`schema`:** Parses `<script type="json/ld">` tags containing structured data (e.g., [Schema.org](https://schema.org/)).
+4.  **`microdata`:** Extracts HTML Microdata annotations (`itemscope itemtype`).
+5.  **`semantic_html`:** Searches for semantic HTML5 tags like `<article>`, `<main>`, and `<section>`.
+6.  **`html`:** Analyzes the HTML structure to find frequently occurring selectors that are likely to contain the main content.
+7.  **`json_state`:** Single-page applications often stash pre-rendered article data in `<script type="application/json">` tags or global variables
     such as `window.__NEXT_DATA__`, `window.__NUXT__`, or `window.STATE`. The JSON-state scraper walks those blobs, finds arrays with
     `title`/`url` pairs, and converts them into the same hashes produced by `HtmlExtractor`.
 
@@ -51,6 +53,10 @@ Enable or disable specific scrapers and adjust their settings:
     scraper:
       wordpress_api:
         enabled: false # default: true
+      sitemap:
+        enabled: true # default: true
+        min_priority: 0.3 # default: 0.3
+        max_age_days: 30 # default: 30
       schema:
         enabled: false # default: true
       semantic_html:

--- a/src/content/docs/ruby-gem/reference/selectors.mdx
+++ b/src/content/docs/ruby-gem/reference/selectors.mdx
@@ -61,34 +61,139 @@ Available options:
 
 ## Paginated Feeds
 
-`html2rss` can follow a single `rel="next"` pagination chain when you configure `selectors.items.pagination.max_pages`.
+Configure `selectors.items.pagination` to fetch items across multiple pages. `html2rss` supports several pagination strategies to handle different website architectures.
+
+### Common Options
+
+- **`strategy`**: The pagination strategy name (default: `rel_next`).
+- **`max_pages`**: The total page budget for the item selector chain, including the initial page (default: `5`).
+
+If you specify `pagination` as a simple integer (e.g., `pagination: 5`), it defaults to the `rel_next` strategy with the specified `max_pages`.
+
+---
+
+### Strategies
+
+#### 1. `rel_next` (Default)
+
+Follows standard HTML next page relationships via `<link rel="next">` or `<a rel="next">` tags.
 
 <Code
   code={`
-  channel:
-    url: "https://example.com/news"
   selectors:
     items:
       selector: "article"
-      pagination:
-        max_pages: 3
-    title:
-      selector: "h1"
-    url:
-      selector: "a"
-      extractor: "href"
+      pagination: 5 # or { strategy: rel_next, max_pages: 5 }
   `}
   lang="yml"
 />
 
-Behavior:
+#### 2. `custom_selector`
 
-- `max_pages` is the total page budget for the item selector chain, including the initial page.
-- `max_pages` is capped by the system request ceiling of 10 pages per feed build.
-- Pagination follows strict `link[rel~="next"]` or `a[rel~="next"]` targets only.
-- Follow-up pages use the current page's effective origin after redirects.
-- Pagination stops when there is no next link, a page repeats, or the shared request budget is exhausted.
-- The same request safeguards apply to pagination and Browserless navigation, including timeout limits, redirect limits, response-size guards, and private-network denial.
+Uses a custom CSS or XPath selector to locate the link pointing to the next page. It reads the element's `href` attribute or text content as the next URL.
+
+- **`selector`** (String, required): The CSS selector or XPath expression for the next-page element.
+
+<Code
+  code={`
+  selectors:
+    items:
+      selector: "article"
+      pagination:
+        strategy: custom_selector
+        selector: "a.next-page-link"
+        max_pages: 5
+  `}
+  lang="yml"
+/>
+
+#### 3. `url_template`
+
+Increments a page number in a query parameter or replaces a `{page}` token inside the URL template.
+
+- **`param`** (String, default: `page`): The name of the query parameter representing the page number.
+- **`start_page`** (Integer, default: `1`): The initial page number.
+- **`step`** (Integer, default: `1`): The step value to increment by for each subsequent page.
+
+If the initial URL contains the `{page}` placeholder, `html2rss` replaces `{page}` with the calculated page number. Otherwise, it appends/replaces the query parameter specified by `param`.
+
+<Code
+  code={`
+  selectors:
+    items:
+      selector: "article"
+      pagination:
+        strategy: url_template
+        param: "page"
+        start_page: 1
+        step: 1
+        max_pages: 5
+  `}
+  lang="yml"
+/>
+
+#### 4. `offset`
+
+Increments a numeric offset in a query parameter or replaces an `{offset}` token inside the URL template.
+
+- **`param`** (String, default: `offset`): The name of the query parameter representing the offset.
+- **`start_offset`** (Integer, default: `0`): The initial offset value.
+- **`increment`** (Integer, default: `20`): The offset value to add for each subsequent page.
+
+If the initial URL contains the `{offset}` placeholder, `html2rss` replaces `{offset}` with the calculated offset. Otherwise, it appends/replaces the query parameter specified by `param`.
+
+<Code
+  code={`
+  selectors:
+    items:
+      selector: "article"
+      pagination:
+        strategy: offset
+        param: "offset"
+        start_offset: 0
+        increment: 20
+        max_pages: 5
+  `}
+  lang="yml"
+/>
+
+#### 5. `json_cursor`
+
+Digs next-page URLs or cursor tokens directly from JSON response payloads.
+
+Requires configuring **either** `cursor_path` or `next_url_path`:
+
+- **`cursor_path`** (String): Dot-notation path to the cursor value in the JSON payload (e.g., `meta.next_cursor`). When present, `html2rss` appends/updates the query parameter specified by `param` (defaults to `cursor`) with the cursor value.
+- **`next_url_path`** (String): Dot-notation path to the next page URL in the JSON payload (e.g., `links.next`).
+- **`param`** (String, default: `cursor`): The query parameter name used with `cursor_path`.
+
+<Code
+  code={`
+  selectors:
+    items:
+      selector: "items"
+      pagination:
+        strategy: json_cursor
+        cursor_path: "meta.next_cursor" # or next_url_path: "links.next"
+        param: "cursor"
+        max_pages: 5
+  `}
+  lang="yml"
+/>
+
+---
+
+### Behavior & Request Budgeting
+
+- **Auto-budgeting**: The request budget (`max_requests`) is automatically calculated and adjusted based on your `max_pages` configuration so you do not need to manually configure `request.max_requests` under normal circumstances.
+- **System ceiling**: The absolute request limit is capped at `10` requests per build. If `max_pages` exceeds the system request ceiling, it will be clamped to the ceiling, and a warning will be logged.
+- **Stop conditions**: Pagination stops automatically if:
+  - The configured `max_pages` is reached.
+  - The request budget is exhausted.
+  - A page yields 0 new items.
+  - An already visited URL is encountered (loop protection).
+  - A network or extraction error occurs.
+- **Request safeguards**: All request safeguards apply to pagination (such as redirect limits, timeout boundaries, private-network denial, and response-size limits).
 
 ## RSS 2.0 Selectors
 

--- a/src/content/docs/ruby-gem/reference/strategy.mdx
+++ b/src/content/docs/ruby-gem/reference/strategy.mdx
@@ -22,6 +22,10 @@ The default strategy chain is:
 
 `faraday` -> `botasaurus` -> `browserless`
 
+Auto fallback shares one request budget across all strategy attempts. For pagination-heavy or dynamic pages, increase `request.max_requests` (or `--max-requests`) when retries exhaust the budget.
+
+Auto fallback decisions are hidden at the default `LOG_LEVEL=warn`; run with `LOG_LEVEL=info` to include them in CLI output.
+
 ## `browserless`
 
 To use the `browserless` strategy, you need a running instance of [Browserless.io](https://www.browserless.io/).
@@ -169,39 +173,55 @@ For custom Browserless websocket endpoints, `BROWSERLESS_IO_API_TOKEN` is mandat
 - `strategy: botasaurus`
 - `BOTASAURUS_SCRAPER_URL` set to your Botasaurus scrape API base URL (for example `http://localhost:4010`)
 
+html2rss still enforces local request policy preflight and timeout budget. Botasaurus handles browser navigation/rendering internals, so some policy details are delegated to upstream execution.
+
 ### Configuration
 
 <Code
   code={`
+  channel:
+    url: "https://example.com"
   strategy: botasaurus
+  auto_source: {}
   request:
-    max_redirects: 5
-    max_requests: 6
     botasaurus:
       navigation_mode: auto
       max_retries: 2
       headless: false
-  channel:
-    url: "https://example.com/protected-listing"
-  auto_source: {}
   `}
   lang="yml"
 />
 
 Supported `request.botasaurus` options:
 
-- `navigation_mode` (`auto`, `get`, `google_get`, `google_get_bypass`)
-- `max_retries` (`0..3`)
-- `wait_for_selector`
-- `wait_timeout_seconds`
-- `block_images`
-- `block_images_and_css`
-- `wait_for_complete_page_load`
-- `headless`
-- `proxy`
-- `user_agent`
-- `window_size` (two integers, for example `[1920, 1080]`)
-- `lang`
+- `navigation_mode` (`auto`, `get`, `google_get`, `google_get_bypass`; default `auto`)
+- `max_retries` (`0..3`; default `2`)
+- `wait_for_selector` (string)
+- `wait_timeout_seconds` (integer)
+- `block_images` (boolean)
+- `block_images_and_css` (boolean)
+- `wait_for_complete_page_load` (boolean)
+- `headless` (boolean, default `false`)
+- `proxy` (string)
+- `user_agent` (string)
+- `window_size` (two-item integer array, for example `[1920, 1080]`)
+- `lang` (string, for example `en-US`)
+
+### Request payload shape
+
+Example scrape-API payload shape:
+
+<Code
+  code={`
+  {
+    "url": "https://example.com",
+    "navigation_mode": "auto",
+    "max_retries": 2,
+    "headless": false
+  }
+  `}
+  lang="json"
+/>
 
 ### Command-Line Usage
 


### PR DESCRIPTION
Documents the pagination strategies implemented in html2rss gem (linked to https://github.com/html2rss/html2rss/pull/404).